### PR TITLE
feat: auto-detect GitLab CI environment for upload metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This CLI tool allows you to easily upload your [Storybook](https://storybook.js.
 
 - **Simple Upload:** Upload your static Storybook build directory with a single command.
 - **Git Integration:** Automatically detects the current Git commit SHA, branch name, and base commit/branch for comparison.
+- **CI Auto-Detection:** Reads predefined CI variables (e.g. GitLab CI/CD) so commit, branch, base branch/commit, and merge request number are resolved automatically inside your pipeline.
 - **Flexible Configuration:** Override detected Git information and API endpoint via command-line flags or environment variables.
 - **CI/CD Ready:** Designed for easy integration into your continuous integration pipelines.
 
@@ -69,9 +70,9 @@ You need a VizDiff **Project Token** to upload builds.
 | `--branch`              | `-b`  | -                       | Git branch name being built.                                                                              | Current branch name         |
 | `--base-branch`         |       | -                       | Base branch name for comparison (e.g., `main`, `master`).                                                 | Default repo branch         |
 | `--base-commit`         |       | -                       | Base commit SHA for comparison.                                                                           | Merge base with base branch |
-| `--pr`                  |       | -                       | GitHub Pull Request number associated with the commit (if applicable).                                    | -                           |
+| `--pr`                  |       | -                       | Pull/merge request number associated with the commit (if applicable).                                     | -                           |
 | `<storybook-build-dir>` |       | -                       | **(Required)** Path to the directory containing your static Storybook build (usually `storybook-static`). | -                           |
-| -                       |       | `VIZDIFF_API_URL`       | Override the VizDiff API endpoint.                                                                        | `https://vizdiff.io/api`    |
+| -                       |       | `VIZDIFF_API_URL`       | VizDiff API endpoint. For self-hosted deployments, point this at your ingress (e.g. `https://vizdiff.corp.example.com/api`). | `https://vizdiff.io/api`    |
 
 **Example with overrides:**
 
@@ -97,10 +98,60 @@ The CLI attempts to automatically determine the correct commit SHA, branch, and 
 
 You can override any of these automatic detections using the corresponding command-line flags if needed.
 
+### CI Environment Auto-Detection
+
+When running inside a supported CI provider, the CLI reads the provider's predefined environment variables instead of relying solely on the local `git` checkout (which on CI is often a shallow or detached clone). The resolution precedence for every metadata value is:
+
+1. **Explicit flags** (e.g. `--commit`, `--branch`, `--pr`) — always win.
+2. **CI environment variables** — used when the corresponding flag is not set.
+3. **Local `git` inference** — used as a final fallback.
+
+#### GitLab CI/CD
+
+GitLab CI/CD is detected via the `GITLAB_CI` environment variable. The following [predefined variables](https://docs.gitlab.com/ci/variables/predefined_variables/) are mapped:
+
+| Metadata    | GitLab variable(s)                                                          |
+| ----------- | -------------------------------------------------------------------------- |
+| Commit SHA  | `CI_COMMIT_SHA`                                                             |
+| Branch      | `CI_COMMIT_REF_NAME` (fallback `CI_COMMIT_BRANCH`)                          |
+| MR number   | `CI_MERGE_REQUEST_IID`                                                      |
+| Base branch | `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` (fallback `CI_DEFAULT_BRANCH`)        |
+| Base commit | `CI_MERGE_REQUEST_TARGET_BRANCH_SHA` (fallback `CI_MERGE_REQUEST_DIFF_BASE_SHA`) |
+
+In a **branch (push) pipeline** only the commit, branch, and `CI_DEFAULT_BRANCH` base branch are available. In a **merge request pipeline** the `CI_MERGE_REQUEST_*` variables additionally supply the MR number and the target (base) branch and commit.
+
+### GitLab CI/CD Usage
+
+Store your VizDiff project token as a [masked CI/CD variable](https://docs.gitlab.com/ci/variables/#mask-a-cicd-variable) named `VIZDIFF_PROJECT_TOKEN`. If you run a self-hosted VizDiff deployment, also add a `VIZDIFF_API_URL` variable pointing at your ingress (e.g. `https://vizdiff.corp.example.com/api`); on vizdiff.io this can be omitted.
+
+Minimal `.gitlab-ci.yml` that builds Storybook and uploads it on both branch pushes and merge requests:
+
+```yaml
+visual-regression:
+  image: node:20
+  rules:
+    # Run on merge request pipelines and on pushes to the default branch.
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  variables:
+    # Required for self-hosted VizDiff. Omit on vizdiff.io.
+    # VIZDIFF_API_URL must point at your self-hosted ingress, e.g.:
+    VIZDIFF_API_URL: "https://vizdiff.corp.example.com/api"
+  script:
+    - npm ci
+    - npm run build-storybook # outputs to ./storybook-static
+    - npx @vizdiff/cli upload storybook-static
+    # VIZDIFF_PROJECT_TOKEN is read from a masked CI/CD variable.
+    # Commit, branch, base branch/commit, and MR number are auto-detected
+    # from the GitLab predefined variables — no extra flags needed.
+```
+
+For merge request pipelines, GitLab automatically exposes `CI_MERGE_REQUEST_IID` and the target branch/commit, so VizDiff will compare against the MR's base and associate the result with the merge request.
+
 ## How it Works
 
 1.  The CLI verifies the existence of necessary Storybook build files (`project.json`, `index.json`) in the specified directory.
-2.  It gathers Git metadata (commit, branch, etc.) unless overridden by flags.
+2.  It gathers Git metadata (commit, branch, etc.) from explicit flags, then CI predefined variables, then the local `git` checkout (in that precedence order).
 3.  The Storybook build directory is compressed into a `.tar.gz` archive.
 4.  The archive is uploaded to the VizDiff API endpoint (`/upload/storybook`) along with the project token and Git metadata.
 5.  VizDiff processes the Storybook, renders components, performs visual diffs against the base build, and reports the results back through the VizDiff web app and any configured GitHub checks.

--- a/src/bin/vizdiff.ts
+++ b/src/bin/vizdiff.ts
@@ -6,6 +6,7 @@ import path from "path"
 import { simpleGit } from "simple-git"
 
 import { checkToken, uploadStorybook } from ".."
+import { type CiMetadata, detectCiMetadata } from "../ci-env"
 import { fatal } from "../log"
 
 type CommandArgs = {
@@ -34,7 +35,7 @@ function main(): void {
       "--base-commit <base-commit-sha>",
       "Base commit SHA for comparison (defaults to the merge base commit)",
     )
-    .option("--pr <pr-number>", "GitHub pull request number associated with this commit (optional)")
+    .option("--pr <pr-number>", "Pull/merge request number associated with this commit (optional)")
     .action((storybookDir: string, options: CommandArgs) => {
       vizdiff(storybookDir, options).catch(fatal)
     })
@@ -48,14 +49,19 @@ function main(): void {
 }
 
 async function vizdiff(storybookDir: string, options: CommandArgs): Promise<void> {
+  // Metadata resolution precedence: explicit flags > CI env vars > local git.
+  const ci = detectCiMetadata()
+
   const projectToken = getToken(options)
-  const commitSha = await getCommitSha(storybookDir, options)
-  const branch = await getBranch(storybookDir, options)
+  const commitSha = await getCommitSha(storybookDir, options, ci)
+  const branch = await getBranch(storybookDir, options, ci)
+  const baseBranchHint = options.baseBranch ?? ci.baseBranch
+  const baseCommitHint = options.baseCommit ?? ci.baseCommitSha
   const [baseCommitSha, baseBranch] =
-    options.baseCommit && options.baseBranch
-      ? [options.baseCommit, options.baseBranch]
-      : await getBaseCommitShaAndBranch(storybookDir, commitSha, branch, options.baseBranch)
-  const prNumber = getPrNumber(options)
+    baseCommitHint && baseBranchHint
+      ? [baseCommitHint, baseBranchHint]
+      : await getBaseCommitShaAndBranch(storybookDir, commitSha, branch, baseBranchHint)
+  const prNumber = getPrNumber(options, ci)
 
   try {
     await uploadStorybook({
@@ -98,8 +104,12 @@ function getToken(options: { token?: string }) {
   return token
 }
 
-async function getCommitSha(storybookDir: string, options: { commit?: string }): Promise<string> {
-  const commitSha = options.commit
+async function getCommitSha(
+  storybookDir: string,
+  options: { commit?: string },
+  ci: CiMetadata,
+): Promise<string> {
+  const commitSha = options.commit ?? ci.commitSha
   if (commitSha) {
     return commitSha
   }
@@ -118,9 +128,14 @@ async function getCommitSha(storybookDir: string, options: { commit?: string }):
   return log.latest.hash
 }
 
-async function getBranch(storybookDir: string, options: { branch?: string }): Promise<string> {
-  if (options.branch) {
-    return options.branch
+async function getBranch(
+  storybookDir: string,
+  options: { branch?: string },
+  ci: CiMetadata,
+): Promise<string> {
+  const branch = options.branch ?? ci.branch
+  if (branch) {
+    return branch
   }
 
   const gitDir = findGitRoot(storybookDir)
@@ -203,9 +218,10 @@ function findGitRoot(dir: string): string | undefined {
   return findGitRoot(parentDir)
 }
 
-// Returns the pull request number if it is a valid number, otherwise undefined
-function getPrNumber(options: { pr?: string | number }): number | undefined {
-  const prNumber = options.pr ? parseInt(options.pr.toString()) : undefined
+// Returns the pull/merge request number if it is a valid number, otherwise undefined
+function getPrNumber(options: { pr?: string | number }, ci: CiMetadata): number | undefined {
+  const raw = options.pr ?? ci.prNumber
+  const prNumber = raw != undefined ? parseInt(raw.toString(), 10) : undefined
   if (prNumber == undefined || isNaN(prNumber) || prNumber < 1) {
     return undefined
   }

--- a/src/ci-env.test.ts
+++ b/src/ci-env.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for CI environment auto-detection. We pass a synthetic `env` object so
+ * the resolver can be exercised without touching the real process environment.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { detectCiMetadata, isGitLabCi } from "./ci-env"
+
+describe("ci-env", () => {
+  describe("isGitLabCi", () => {
+    it("returns true when GITLAB_CI is set", () => {
+      expect(isGitLabCi({ GITLAB_CI: "true" })).toBe(true)
+    })
+
+    it("returns false when GITLAB_CI is empty or unset", () => {
+      expect(isGitLabCi({})).toBe(false)
+      expect(isGitLabCi({ GITLAB_CI: "" })).toBe(false)
+    })
+  })
+
+  describe("detectCiMetadata", () => {
+    it("returns an empty object outside of a supported CI provider", () => {
+      expect(detectCiMetadata({})).toEqual({})
+    })
+
+    it("resolves metadata for a GitLab branch (push) pipeline", () => {
+      const env = {
+        GITLAB_CI: "true",
+        CI_COMMIT_SHA: "a".repeat(40),
+        CI_COMMIT_REF_NAME: "main",
+        CI_COMMIT_BRANCH: "main",
+        CI_DEFAULT_BRANCH: "main",
+      }
+      expect(detectCiMetadata(env)).toEqual({
+        commitSha: "a".repeat(40),
+        branch: "main",
+        baseBranch: "main",
+        baseCommitSha: undefined,
+        prNumber: undefined,
+      })
+    })
+
+    it("resolves metadata for a GitLab merge request pipeline", () => {
+      const env = {
+        GITLAB_CI: "true",
+        CI_COMMIT_SHA: "a".repeat(40),
+        CI_COMMIT_REF_NAME: "feature/new-button",
+        CI_MERGE_REQUEST_IID: "42",
+        CI_MERGE_REQUEST_TARGET_BRANCH_NAME: "main",
+        CI_MERGE_REQUEST_TARGET_BRANCH_SHA: "b".repeat(40),
+        CI_MERGE_REQUEST_DIFF_BASE_SHA: "c".repeat(40),
+        CI_DEFAULT_BRANCH: "main",
+      }
+      expect(detectCiMetadata(env)).toEqual({
+        commitSha: "a".repeat(40),
+        branch: "feature/new-button",
+        baseBranch: "main",
+        baseCommitSha: "b".repeat(40),
+        prNumber: 42,
+      })
+    })
+
+    it("prefers CI_COMMIT_BRANCH when CI_COMMIT_REF_NAME is absent", () => {
+      const env = {
+        GITLAB_CI: "true",
+        CI_COMMIT_SHA: "a".repeat(40),
+        CI_COMMIT_BRANCH: "develop",
+      }
+      expect(detectCiMetadata(env).branch).toBe("develop")
+    })
+
+    it("falls back to CI_DEFAULT_BRANCH when no merge request target branch is set", () => {
+      const env = {
+        GITLAB_CI: "true",
+        CI_COMMIT_SHA: "a".repeat(40),
+        CI_COMMIT_REF_NAME: "develop",
+        CI_DEFAULT_BRANCH: "main",
+      }
+      expect(detectCiMetadata(env).baseBranch).toBe("main")
+    })
+
+    it("falls back to CI_MERGE_REQUEST_DIFF_BASE_SHA for the base commit", () => {
+      const env = {
+        GITLAB_CI: "true",
+        CI_COMMIT_SHA: "a".repeat(40),
+        CI_COMMIT_REF_NAME: "feature/x",
+        CI_MERGE_REQUEST_IID: "7",
+        CI_MERGE_REQUEST_TARGET_BRANCH_NAME: "main",
+        CI_MERGE_REQUEST_DIFF_BASE_SHA: "d".repeat(40),
+      }
+      expect(detectCiMetadata(env).baseCommitSha).toBe("d".repeat(40))
+    })
+
+    it("ignores empty predefined variables", () => {
+      const env = {
+        GITLAB_CI: "true",
+        CI_COMMIT_SHA: "a".repeat(40),
+        CI_COMMIT_REF_NAME: "",
+        CI_COMMIT_BRANCH: "",
+        CI_MERGE_REQUEST_IID: "",
+      }
+      const meta = detectCiMetadata(env)
+      expect(meta.branch).toBeUndefined()
+      expect(meta.prNumber).toBeUndefined()
+    })
+
+    it("ignores invalid merge request IIDs", () => {
+      const env = {
+        GITLAB_CI: "true",
+        CI_COMMIT_SHA: "a".repeat(40),
+        CI_MERGE_REQUEST_IID: "not-a-number",
+      }
+      expect(detectCiMetadata(env).prNumber).toBeUndefined()
+    })
+  })
+})

--- a/src/ci-env.ts
+++ b/src/ci-env.ts
@@ -1,0 +1,80 @@
+/**
+ * Auto-detection of CI environment metadata.
+ *
+ * When the CLI runs inside a CI provider, the commit SHA, branch, base branch,
+ * base commit, and pull/merge request number are usually exposed as predefined
+ * environment variables. Reading these is more reliable than inferring them from
+ * the local `git` checkout, which on CI is often a shallow/detached clone.
+ *
+ * Each value is only populated when the provider exposes it. Empty strings are
+ * treated as "not set" so a blank predefined variable does not override a value
+ * resolved from a flag or local git.
+ */
+export type CiMetadata = {
+  commitSha?: string
+  branch?: string
+  baseBranch?: string
+  baseCommitSha?: string
+  prNumber?: number
+}
+
+type Env = Record<string, string | undefined>
+
+/**
+ * Resolve CI metadata from predefined environment variables. Returns an empty
+ * object when no supported CI provider is detected.
+ */
+export function detectCiMetadata(env: Env = process.env): CiMetadata {
+  if (isGitLabCi(env)) {
+    return detectGitLabCi(env)
+  }
+  return {}
+}
+
+/** Returns true when running inside GitLab CI/CD. */
+export function isGitLabCi(env: Env = process.env): boolean {
+  return firstNonEmpty(env.GITLAB_CI) != undefined
+}
+
+/**
+ * Resolve metadata from GitLab CI/CD predefined variables.
+ *
+ * @see https://docs.gitlab.com/ci/variables/predefined_variables/
+ */
+function detectGitLabCi(env: Env): CiMetadata {
+  // In a merge request pipeline, CI_COMMIT_REF_NAME points at the source branch
+  // and CI_MERGE_REQUEST_* variables describe the target. In a branch (push)
+  // pipeline, only the CI_COMMIT_* and CI_DEFAULT_BRANCH variables are present.
+  return {
+    commitSha: firstNonEmpty(env.CI_COMMIT_SHA),
+    branch: firstNonEmpty(env.CI_COMMIT_REF_NAME, env.CI_COMMIT_BRANCH),
+    prNumber: parsePrNumber(env.CI_MERGE_REQUEST_IID),
+    baseBranch: firstNonEmpty(env.CI_MERGE_REQUEST_TARGET_BRANCH_NAME, env.CI_DEFAULT_BRANCH),
+    baseCommitSha: firstNonEmpty(
+      env.CI_MERGE_REQUEST_TARGET_BRANCH_SHA,
+      env.CI_MERGE_REQUEST_DIFF_BASE_SHA,
+    ),
+  }
+}
+
+/** Returns the first argument that is a non-empty string, otherwise undefined. */
+function firstNonEmpty(...values: (string | undefined)[]): string | undefined {
+  for (const value of values) {
+    if (value != undefined && value.trim() !== "") {
+      return value
+    }
+  }
+  return undefined
+}
+
+/** Parses a pull/merge request number, returning undefined when invalid. */
+function parsePrNumber(value: string | undefined): number | undefined {
+  if (value == undefined || value.trim() === "") {
+    return undefined
+  }
+  const prNumber = parseInt(value, 10)
+  if (isNaN(prNumber) || prNumber < 1) {
+    return undefined
+  }
+  return prNumber
+}


### PR DESCRIPTION
## Summary

Adds GitLab CI/CD environment auto-detection so `vizdiff upload` resolves Git metadata from the pipeline's predefined variables instead of relying solely on the local (often shallow/detached) `git` checkout.

A small resolver (`src/ci-env.ts`) reads the variables and feeds them into the existing metadata pipeline in `src/bin/vizdiff.ts`. Detection is gated on the `GITLAB_CI` env var.

## Detected variables (GitLab CI/CD)

| Metadata    | GitLab variable(s) |
| ----------- | ------------------ |
| Commit SHA  | `CI_COMMIT_SHA` |
| Branch      | `CI_COMMIT_REF_NAME` (fallback `CI_COMMIT_BRANCH`) |
| MR number   | `CI_MERGE_REQUEST_IID` |
| Base branch | `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` (fallback `CI_DEFAULT_BRANCH`) |
| Base commit | `CI_MERGE_REQUEST_TARGET_BRANCH_SHA` (fallback `CI_MERGE_REQUEST_DIFF_BASE_SHA`) |

Empty predefined variables are treated as unset so they never clobber a flag or local-git value.

## Precedence

For every metadata value: **explicit flags > CI env vars > local `git` inference**. Existing local-git behavior is unchanged and remains the final fallback.

## README additions

- New **CI Environment Auto-Detection** subsection documenting the precedence rules and the full GitLab variable mapping.
- New **GitLab CI/CD Usage** section with a minimal `.gitlab-ci.yml` snippet covering both branch (push) and merge request pipelines, using masked `VIZDIFF_PROJECT_TOKEN` / `VIZDIFF_API_URL` CI variables.
- Clarified that `VIZDIFF_API_URL` must point at the self-hosted ingress (e.g. `https://vizdiff.corp.example.com/api`); no new default added.
- `--pr` help text generalized from "GitHub pull request" to "pull/merge request".

## Tests / validation

- New `src/ci-env.test.ts` (10 tests) mocks GitLab env vars and asserts resolved metadata for push pipelines, MR pipelines, fallbacks, and empty/invalid values.
- `yarn test` — 30 passed (2 files). `yarn lint` — clean. `yarn build` — clean. `vizdiff upload --help` renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)