### PR TITLE
ci(release): run in the `release` environment for scoped npm Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Scopes npm Trusted Publishing (OIDC) to this environment. No protection rules, so releases
+    # still run automatically on push to main — no manual-approval pause.
+    environment: release
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Scopes npm **Trusted Publishing (OIDC)** to a dedicated `release` GitHub Actions environment.

- Adds `environment: release` to the release job.
- The `release` environment was created with **no protection rules**, so releases still run automatically on push to `main` — **no manual-approval pause**.
- Pairs with the npm Trusted Publishing config (publisher: repo `vizdiff-io/cli`, workflow `release.yml`, environment `release`), so npm only trusts publishes that run inside this environment.

Once this is merged and the npm trusted-publisher entry is saved, the release publishes token-lessly via OIDC (the expired `NPM_TOKEN` is no longer needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)