### PR TITLE
ci(release): drop the dead NPM_TOKEN env (publishing is OIDC-only)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,5 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Publishing uses npm Trusted Publishing (OIDC) via the `release` environment, so no
+          # NPM_TOKEN is needed — the secret has been removed.


### PR DESCRIPTION
Publishing now runs entirely on npm **Trusted Publishing (OIDC)** via the `release` environment, and the `NPM_TOKEN` secret has been deleted. This removes the now-dead `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` reference from the `npx semantic-release` step (it was resolving to an empty string).

No behavior change — OIDC already takes precedence; this is config cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)